### PR TITLE
updated operationHeaders: comments about dynamically set header values

### DIFF
--- a/website/docs/handlers/graphql.mdx
+++ b/website/docs/handlers/graphql.mdx
@@ -49,6 +49,7 @@ sources:
         endpoint: http://my-service-url:3000/graphql
         operationHeaders:
           # Please do not use capital letters while getting the headers
+          # Use "{context.headers['x-my-api-token']}" if you want just the value of the header
           Authorization: Bearer {context.headers['x-my-api-token']}
           # You can also access to the cookies like below;
           # Authorization: Bearer {context.cookies.myApiToken}


### PR DESCRIPTION
## Description
Email:
I had an issue using the docs with the dynamic header values section.
The line "Authorization: Bearer {context.headers['x-my-api-token']}"
I needed just the value of the header and not the word Bearer in front. So got it working with "{context.headers['x-my-api-token']}" with double quotes around it, maybe you could add this to the docs.

Laurin - The Guild |   | 2:19 PM (6 hours ago)
Would you mind sending a pull request with updated documentation?  https://github.com/Urigo/graphql-mesh/blob/master/website/docs/handlers/graphql.mdx 

laurin@emails.the-guild.dev said to submit a PR. I gave feedback about the GraphQL docs missing some info at operatHeaders dynamically getting header values. 

## Checklist:

- [ x] I have followed the [CONTRIBUTING](https://github.com/the-guild-org/Stack/blob/master/CONTRIBUTING.md) doc and the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings